### PR TITLE
feat : increaseViewCount logic improvement

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+services:
+  redis:
+    image: redis:alpine
+    container_name: my-redis
+    ports:
+      - "6379:6379"

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,24 @@
             <optional>true</optional>
         </dependency>
 
+        <!-- Caffeine Cache - Redis 대용 -->
+        <!-- Source: https://mvnrepository.com/artifact/com.github.ben-manes.caffeine/caffeine -->
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+            <version>3.2.3</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <!-- Redis Starter       -->
+        <!-- Source: https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-data-redis -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-redis</artifactId>
+            <version>4.1.0-M1</version>
+            <scope>compile</scope>
+        </dependency>
+
         <!-- Test -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/nullpoint/fifteenmintable/controller/RecipeController.java
+++ b/src/main/java/com/nullpoint/fifteenmintable/controller/RecipeController.java
@@ -4,6 +4,7 @@ import com.nullpoint.fifteenmintable.dto.ApiRespDto;
 import com.nullpoint.fifteenmintable.dto.recipe.*;
 import com.nullpoint.fifteenmintable.security.model.PrincipalUser;
 import com.nullpoint.fifteenmintable.service.RecipeService;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -50,9 +51,11 @@ public class RecipeController {
     @GetMapping("/detail/{recipeId}")
     public ResponseEntity<ApiRespDto<RecipeDetailRespDto>> getRecipeDetail(
             @PathVariable Integer boardId,
-            @PathVariable Integer recipeId
+            @PathVariable Integer recipeId,
+            HttpServletRequest request
     ) {
-        return ResponseEntity.ok(recipeService.getRecipeDetail(boardId, recipeId));
+        String userIp = this.getClientIp(request);
+        return ResponseEntity.ok(recipeService.getRecipeDetail(boardId, recipeId, userIp));
     }
 
     @PutMapping("/modify/{recipeId}")
@@ -72,5 +75,38 @@ public class RecipeController {
             @AuthenticationPrincipal PrincipalUser principalUser
     ) {
         return ResponseEntity.ok(recipeService.removeRecipe(boardId, recipeId, principalUser));
+    }
+
+    // IP 가져오기 로직 - 재사용 필요시 util 폴더에 등록
+    private String getClientIp(HttpServletRequest request) {
+        String ip = request.getHeader("X-Forwarded-For");
+
+        // ,(Comma) 분리 로직
+        if (ip != null && ip.length() != 0 && !"unknown".equalsIgnoreCase(ip)) {
+            // 여러 개일 경우 첫 번째 IP가 실제 클라이언트 IP입니다.
+            int index = ip.indexOf(",");
+            if (index != -1) {
+                return ip.substring(0, index);
+            }
+            return ip;
+        }
+
+        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+            ip = request.getHeader("Proxy-Client-IP");
+        }
+        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+            ip = request.getHeader("WL-Proxy-Client-IP");
+        }
+        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+            ip = request.getHeader("HTTP_CLIENT_IP");
+        }
+        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+            ip = request.getHeader("HTTP_X_FORWARDED_FOR");
+        }
+        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+            ip = request.getRemoteAddr();
+        }
+
+        return ip;
     }
 }

--- a/src/main/java/com/nullpoint/fifteenmintable/service/RecipeService.java
+++ b/src/main/java/com/nullpoint/fifteenmintable/service/RecipeService.java
@@ -1,5 +1,7 @@
 package com.nullpoint.fifteenmintable.service;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.nullpoint.fifteenmintable.dto.hashtag.HashtagRespDto;
 import com.nullpoint.fifteenmintable.dto.recipe.*;
 import com.nullpoint.fifteenmintable.dto.ApiRespDto;
@@ -12,13 +14,20 @@ import com.nullpoint.fifteenmintable.repository.CommentRepository;
 import com.nullpoint.fifteenmintable.repository.RecipeHashtagRepository;
 import com.nullpoint.fifteenmintable.repository.RecipeRepository;
 import com.nullpoint.fifteenmintable.security.model.PrincipalUser;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 @Service
+@RequiredArgsConstructor
+@Slf4j
 public class RecipeService {
 
     @Autowired
@@ -32,6 +41,13 @@ public class RecipeService {
 
     @Autowired
     private NotificationService notificationService;
+
+    private final StringRedisTemplate redisTemplate;
+    // Redis가 죽었을 때 쓸 비상용 로컬 캐시 (24시간 뒤 자동 삭제, 최대 3000개)
+    private final Cache<String, Boolean> localFallbackCache = Caffeine.newBuilder()
+            .expireAfterWrite(60 * 24, TimeUnit.MINUTES)
+            .maximumSize(3000)
+            .build();
 
     @Transactional
     public ApiRespDto<Integer> addRecipe(Integer boardId, AddRecipeReqDto addRecipeReqDto, PrincipalUser principalUser) {
@@ -158,11 +174,36 @@ public class RecipeService {
 
 
     @Transactional
-    public ApiRespDto<RecipeDetailRespDto> getRecipeDetail(Integer boardId, Integer recipeId) {
+    public ApiRespDto<RecipeDetailRespDto> getRecipeDetail(Integer boardId, Integer recipeId, String userIp) {
         if (boardId == null) throw new BadRequestException("boardId는 필수입니다.");
         if (recipeId == null) throw new BadRequestException("recipeId는 필수입니다.");
 
-        recipeRepository.increaseViewCount(recipeId);
+//        조회수 중복 방지 로직!
+//        1. Redis 확인
+//        2. Redis 연결 실패 시 -> 로컬 캐시로 Fallback
+//        3. 대용 로직으로 로컬 캐시(Caffeine Cache) 사용해서 조회수 중복 최소화.
+
+//        Redis 설치후 아래 명령 실행
+//        docker-compose up -d
+
+        String key = "view_log:" + recipeId + ":" + userIp;
+
+        try {
+            // 1. Redis 확인
+            if (redisTemplate.opsForValue().get(key) == null) {
+                recipeRepository.increaseViewCount(recipeId); // DB 증가
+                redisTemplate.opsForValue().set(key, "1", Duration.ofHours(24));
+            }
+        } catch (Exception e) {
+            // 2. Redis 연결 실패 시 -> 로컬 캐시로 Fallback
+            log.warn("Redis 연결 실패! 로컬 캐시로 전환합니다. ({})", e.getMessage());
+
+            // 로컬 캐시에 없으면 카운트 증가
+            if (localFallbackCache.getIfPresent(key) == null) {
+                recipeRepository.increaseViewCount(recipeId); // DB 증가
+                localFallbackCache.put(key, true); // 로컬에 기록
+            }
+        }
 
         RecipeDetailRespDto detail = recipeRepository.getRecipeDetail(boardId, recipeId)
                 .orElseThrow(() -> new NotFoundException("해당 레시피가 존재하지 않습니다."));


### PR DESCRIPTION
뷰카운트 로직 개선

기존 : 새로 고침시 무한 증가
현재 :  IP address와 recipeId로 이루어진 KV cache 로직 활용해서 중복된 조회수 증가 방어
KV cache 저장 장소는
1. Redis API 확인해서 있는지 확인하고
2. 없으면 caffeine cache 로 로컬 캐쉬 생성해서 사용함
3. redis, caffeine cache 둘 다 24시간 이후 자동 삭제 되도록 로직 구현