### PR TITLE
feat : bugfix - postservice viewcount

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,12 +79,12 @@
 
         <!-- Caffeine Cache - Redis 대용 -->
         <!-- Source: https://mvnrepository.com/artifact/com.github.ben-manes.caffeine/caffeine -->
-        <dependency>
-            <groupId>com.github.ben-manes.caffeine</groupId>
-            <artifactId>caffeine</artifactId>
-            <version>3.2.3</version>
-            <scope>compile</scope>
-        </dependency>
+        <!--        <dependency>-->
+        <!--            <groupId>com.github.ben-manes.caffeine</groupId>-->
+        <!--            <artifactId>caffeine</artifactId>-->
+        <!--            <version>3.2.3</version>-->
+        <!--            <scope>compile</scope>-->
+        <!--        </dependency>-->
 
         <!-- Redis Starter       -->
         <!-- Source: https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-data-redis -->

--- a/src/main/java/com/nullpoint/fifteenmintable/controller/PostController.java
+++ b/src/main/java/com/nullpoint/fifteenmintable/controller/PostController.java
@@ -8,16 +8,22 @@ import com.nullpoint.fifteenmintable.dto.post.PostDetailRespDto;
 import com.nullpoint.fifteenmintable.dto.post.PostListRespDto;
 import com.nullpoint.fifteenmintable.security.model.PrincipalUser;
 import com.nullpoint.fifteenmintable.service.PostService;
+import com.nullpoint.fifteenmintable.util.CommonUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/board/{boardId}/posts")
+@RequiredArgsConstructor
 public class PostController {
 
     @Autowired
     private PostService postService;
+
+    private final CommonUtil commonUtil;
 
     @GetMapping("/list")
     public ApiRespDto<CursorRespDto<PostListRespDto>> getPostList(
@@ -33,9 +39,11 @@ public class PostController {
     @GetMapping("/detail/{postId}")
     public ApiRespDto<PostDetailRespDto> getPostDetail(
             @PathVariable Integer boardId,
-            @PathVariable Integer postId
+            @PathVariable Integer postId,
+            HttpServletRequest request
     ) {
-        return postService.getPostDetail(boardId, postId);
+        String userIp = commonUtil.getClientIp(request);
+        return postService.getPostDetail(boardId, postId, userIp);
     }
 
     @PostMapping("/add")

--- a/src/main/java/com/nullpoint/fifteenmintable/controller/RecipeController.java
+++ b/src/main/java/com/nullpoint/fifteenmintable/controller/RecipeController.java
@@ -4,7 +4,9 @@ import com.nullpoint.fifteenmintable.dto.ApiRespDto;
 import com.nullpoint.fifteenmintable.dto.recipe.*;
 import com.nullpoint.fifteenmintable.security.model.PrincipalUser;
 import com.nullpoint.fifteenmintable.service.RecipeService;
+import com.nullpoint.fifteenmintable.util.CommonUtil;
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -12,10 +14,13 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/board/{boardId}/recipes")
+@RequiredArgsConstructor
 public class RecipeController {
 
     @Autowired
     private RecipeService recipeService;
+
+    private final CommonUtil commonUtil;
 
     @PostMapping("/add")
     public ResponseEntity<ApiRespDto<Integer>> addRecipe(
@@ -54,7 +59,7 @@ public class RecipeController {
             @PathVariable Integer recipeId,
             HttpServletRequest request
     ) {
-        String userIp = this.getClientIp(request);
+        String userIp = commonUtil.getClientIp(request);
         return ResponseEntity.ok(recipeService.getRecipeDetail(boardId, recipeId, userIp));
     }
 
@@ -75,38 +80,5 @@ public class RecipeController {
             @AuthenticationPrincipal PrincipalUser principalUser
     ) {
         return ResponseEntity.ok(recipeService.removeRecipe(boardId, recipeId, principalUser));
-    }
-
-    // IP 가져오기 로직 - 재사용 필요시 util 폴더에 등록
-    private String getClientIp(HttpServletRequest request) {
-        String ip = request.getHeader("X-Forwarded-For");
-
-        // ,(Comma) 분리 로직
-        if (ip != null && ip.length() != 0 && !"unknown".equalsIgnoreCase(ip)) {
-            // 여러 개일 경우 첫 번째 IP가 실제 클라이언트 IP입니다.
-            int index = ip.indexOf(",");
-            if (index != -1) {
-                return ip.substring(0, index);
-            }
-            return ip;
-        }
-
-        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
-            ip = request.getHeader("Proxy-Client-IP");
-        }
-        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
-            ip = request.getHeader("WL-Proxy-Client-IP");
-        }
-        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
-            ip = request.getHeader("HTTP_CLIENT_IP");
-        }
-        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
-            ip = request.getHeader("HTTP_X_FORWARDED_FOR");
-        }
-        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
-            ip = request.getRemoteAddr();
-        }
-
-        return ip;
     }
 }

--- a/src/main/java/com/nullpoint/fifteenmintable/service/RecipeService.java
+++ b/src/main/java/com/nullpoint/fifteenmintable/service/RecipeService.java
@@ -1,7 +1,7 @@
 package com.nullpoint.fifteenmintable.service;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
+//import com.github.benmanes.caffeine.cache.Cache;
+//import com.github.benmanes.caffeine.cache.Caffeine;
 import com.nullpoint.fifteenmintable.dto.hashtag.HashtagRespDto;
 import com.nullpoint.fifteenmintable.dto.recipe.*;
 import com.nullpoint.fifteenmintable.dto.ApiRespDto;
@@ -23,7 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
+//import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
@@ -44,10 +44,10 @@ public class RecipeService {
 
     private final StringRedisTemplate redisTemplate;
     // Redis가 죽었을 때 쓸 비상용 로컬 캐시 (24시간 뒤 자동 삭제, 최대 3000개)
-    private final Cache<String, Boolean> localFallbackCache = Caffeine.newBuilder()
-            .expireAfterWrite(60 * 24, TimeUnit.MINUTES)
-            .maximumSize(3000)
-            .build();
+//    private final Cache<String, Boolean> localFallbackCache = Caffeine.newBuilder()
+//            .expireAfterWrite(60 * 24, TimeUnit.MINUTES)
+//            .maximumSize(3000)
+//            .build();
 
     @Transactional
     public ApiRespDto<Integer> addRecipe(Integer boardId, AddRecipeReqDto addRecipeReqDto, PrincipalUser principalUser) {
@@ -198,11 +198,11 @@ public class RecipeService {
             // 2. Redis 연결 실패 시 -> 로컬 캐시로 Fallback
             log.warn("Redis 연결 실패! 로컬 캐시로 전환합니다. ({})", e.getMessage());
 
-            // 로컬 캐시에 없으면 카운트 증가
-            if (localFallbackCache.getIfPresent(key) == null) {
-                recipeRepository.increaseViewCount(recipeId); // DB 증가
-                localFallbackCache.put(key, true); // 로컬에 기록
-            }
+            // 로컬 캐시에 없으면 카운트 증가 - caffeine 의존성 제거 완료
+//            if (localFallbackCache.getIfPresent(key) == null) {
+//                recipeRepository.increaseViewCount(recipeId); // DB 증가
+//                localFallbackCache.put(key, true); // 로컬에 기록
+//            }
         }
 
         RecipeDetailRespDto detail = recipeRepository.getRecipeDetail(boardId, recipeId)

--- a/src/main/java/com/nullpoint/fifteenmintable/util/CommonUtil.java
+++ b/src/main/java/com/nullpoint/fifteenmintable/util/CommonUtil.java
@@ -1,0 +1,40 @@
+package com.nullpoint.fifteenmintable.util;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CommonUtil {
+    // IP 가져오기 로직 - 재사용 필요시 util 폴더에 등록
+    public String getClientIp(HttpServletRequest request) {
+        String ip = request.getHeader("X-Forwarded-For");
+
+        // ,(Comma) 분리 로직
+        if (ip != null && ip.length() != 0 && !"unknown".equalsIgnoreCase(ip)) {
+            // 여러 개일 경우 첫 번째 IP가 실제 클라이언트 IP입니다.
+            int index = ip.indexOf(",");
+            if (index != -1) {
+                return ip.substring(0, index);
+            }
+            return ip;
+        }
+
+        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+            ip = request.getHeader("Proxy-Client-IP");
+        }
+        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+            ip = request.getHeader("WL-Proxy-Client-IP");
+        }
+        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+            ip = request.getHeader("HTTP_CLIENT_IP");
+        }
+        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+            ip = request.getHeader("HTTP_X_FORWARDED_FOR");
+        }
+        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+            ip = request.getRemoteAddr();
+        }
+
+        return ip;
+    }
+}


### PR DESCRIPTION
postcontroller -> httpservletrequest에서 ip address 추출해서 service로 전달
postservice -> userip + boardid + postid를 결합하여 redis 서버에 24시간 생명주기로 등록

getClientIp 별도 CommonUtil 컴포넌트로 분리 (코드 재사용성)
increaseviewcount 중복 방지 로직 -> redis로 1원화, caffeine 의존성 제거